### PR TITLE
Modify LineLength check to accept lines up to 100 characters

### DIFF
--- a/.github/linters/sun_checks.xml
+++ b/.github/linters/sun_checks.xml
@@ -57,6 +57,7 @@
   <module name="FileLength"/>
   <module name="LineLength">
     <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
   </module>
 
   <!-- Checks for whitespace                               -->


### PR DESCRIPTION
Note that `package` and `import` statements should not be checked by the linter: https://github.com/checkstyle/checkstyle/issues/2433