### PR TITLE
Undo the changes in placesFetcher from resultsPage PR merge as it was outdated

### DIFF
--- a/project/src/main/java/com/google/sps/data/PlacesFetcher.java
+++ b/project/src/main/java/com/google/sps/data/PlacesFetcher.java
@@ -31,18 +31,7 @@ import java.util.List;
 
 public class PlacesFetcher {
 
-   /**
-     * Those constants are temporaraly hardcoded for M0. In next versions those same
-     * constants will be fields of a UserPrefrences instance passed to fetch() by
-     * the Servlet.
-     */
-    private static final LatLng LOCATION = new LatLng(32.080576, 34.780641); // Rabin Square TLV;
-    private static final ImmutableList<String> CUISINES = ImmutableList.of("sushi", "burger");
-    private static final PriceLevel MAX_PRICE_LEVEL = PriceLevel.values()[2];
-    private static final boolean OPEN_NOW = true;
-
-    /**
-     * The type of places that will be searched is RESTAURANT. Since most places
+    /** The type of places that will be searched is RESTAURANT. Since most places
      * that deliver food are not tagged as "MEAL-DELIVERY" type at Google Places but
      * rather as "RESTAURANT" this is the most suitable type to search for.
      */


### PR DESCRIPTION
Sorry for the mess.
When merging the resultsPage PR, since I merged it after merging the placesFetcherM1 PR it changed back the placesFetcher to a previous version. So this PR is to fix this and return the placesFetcher in master to the placesFetcherM1 version.